### PR TITLE
Marketvendor endpoints

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -8,4 +8,21 @@ class Api::V0::MarketVendorsController < ApplicationController
     end
   end
 
+  def create
+    market_vendor = MarketVendor.new(market_vendor_params)
+      if market_vendor.save 
+        render json: {message: "Successfully added vendor to market"}, status: :created
+      elsif params[:market_id].nil? || params[:vendor_id].nil?
+        render json: ErrorSerializer.invalid(market_vendor.errors), status: :bad_request
+      elsif MarketVendor.find_by(market_vendor_params)
+        render json: ErrorSerializer.invalid(market_vendor.errors), status: :unprocessable_entity
+      else
+        render json: ErrorSerializer.invalid(market_vendor.errors), status: :not_found
+      end
+  end
+
+  private
+  def market_vendor_params
+    params.permit(:market_id, :vendor_id)
+  end
 end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -21,6 +21,15 @@ class Api::V0::MarketVendorsController < ApplicationController
       end
   end
 
+  def destroy
+    market_vendor = MarketVendor.find_by(market_vendor_params)
+    if market_vendor.nil?
+      render json: ErrorSerializer.no_association(market_vendor_params.to_hash), status: :not_found
+    else
+      market_vendor.delete
+    end
+  end
+
   private
   def market_vendor_params
     params.permit(:market_id, :vendor_id)

--- a/app/models/market_vendor.rb
+++ b/app/models/market_vendor.rb
@@ -1,4 +1,13 @@
 class MarketVendor < ApplicationRecord 
   belongs_to :market
   belongs_to :vendor
+
+  validate :unique_entry
+
+  def unique_entry
+    found = MarketVendor.find_by(market_id: self.market_id, vendor_id: self.vendor_id)
+    if !found.nil?
+      errors.add(:market_vendor, "association between market with 'id'=#{self.market_id} and vendor with 'id'=#{self.vendor_id} already exists")
+    end
+  end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -17,4 +17,14 @@ class ErrorSerializer
     ]
   }
   end
+
+  def self.no_association(ids)
+    {
+      errors: [
+          {
+              detail: "No association exists between market with 'id'=#{ids["market_id"] || "N/A"} AND vendor with 'id'=#{ids["vendor_id"] || "N/A"}"
+          }
+      ]
+  }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         resources :vendors, only: [:index], controller: :market_vendors
       end
       resources :vendors, only: [:show, :create, :update, :destroy]
-      resources :market_vendors, only: [:create]
+      resource :market_vendors, only: [:create, :destroy]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         resources :vendors, only: [:index], controller: :market_vendors
       end
       resources :vendors, only: [:show, :create, :update, :destroy]
+      resources :market_vendors, only: [:create]
     end
   end
 end

--- a/spec/models/market_vendor_spec.rb
+++ b/spec/models/market_vendor_spec.rb
@@ -5,4 +5,18 @@ RSpec.describe MarketVendor do
     it { should belong_to :market }
     it { should belong_to :vendor }
   end
+
+  describe "validations" do
+    it "should validate uniqueness" do
+      markets = create_list(:market, 2)
+      vendors = create_list(:vendor, 2)
+      MarketVendor.create!(market: markets[0], vendor: vendors[0])
+      MarketVendor.create!(market: markets[1], vendor: vendors[1])
+      
+      expect { MarketVendor.create!(market: markets[0], vendor: vendors[0]) }.to raise_error("Validation failed: Market vendor association between market with 'id'=#{markets[0].id} and vendor with 'id'=#{vendors[0].id} already exists")
+      expect { MarketVendor.create!(market: markets[1], vendor: vendors[0]) }.not_to raise_error
+      expect { MarketVendor.create!(market: markets[0], vendor: vendors[1]) }.not_to raise_error
+      expect { MarketVendor.create!(market: markets[1], vendor: vendors[1]) }.to raise_error("Validation failed: Market vendor association between market with 'id'=#{markets[1].id} and vendor with 'id'=#{vendors[1].id} already exists")
+    end
+  end
 end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -36,4 +36,30 @@ RSpec.describe ErrorSerializer do
 
     expect(ErrorSerializer.invalid(vendor.errors)).to eq(expected)
   end
+
+  it "formats errors when a market_vendor association doesn't exist" do
+    market_vendor = MarketVendor.find_by(market_id: 43, vendor_id: 76)
+
+    expected = {
+      errors: [
+            {
+              detail: "No association exists between market with 'id'=43 AND vendor with 'id'=76"
+            }
+          ]
+        }
+
+    expect(ErrorSerializer.no_association({"market_id" => 43, "vendor_id" => 76})).to eq(expected)
+  end
+
+  it "formats errors when a market_vendor request is missing an id" do
+    expected = {
+      errors: [
+            {
+              detail: "No association exists between market with 'id'=N/A AND vendor with 'id'=N/A"
+            }
+          ]
+        }
+
+    expect(ErrorSerializer.no_association({})).to eq(expected)
+  end
 end


### PR DESCRIPTION
Add endpoints to create and delete a market_vendor association

Error handling implemented for instances when:

- Desired Market id and/or Vendor id do not exist
- The association between the two given ids already exists (when creating)
- A market_vendor with the two given ids does NOT currently exist (when deleting)