### PR TITLE
Vendor states

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -24,6 +24,10 @@ class Api::V0::VendorsController < ApplicationController
     render json: VendorSerializer.new(Vendor.multiple_states)
   end
 
+  def popular_states
+    render json: StateSerializer.serialize(Vendor.popular_states(params[:limit]))
+  end
+
   private
 
   def find_vendor

--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -2,6 +2,10 @@ class Api::V0::VendorsController < ApplicationController
   before_action :find_vendor, only: [:show, :update, :destroy]
   before_action :validate_credit_accepted, only: [:create, :update]
 
+  def index
+    render json: VendorSerializer.new(Vendor.search(params[:state]))
+  end
+
   def show
     render json: VendorSerializer.new(@vendor)
   end

--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -20,6 +20,10 @@ class Api::V0::VendorsController < ApplicationController
     @vendor.destroy
   end
 
+  def multiple_states
+    render json: VendorSerializer.new(Vendor.multiple_states)
+  end
+
   private
 
   def find_vendor

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -10,4 +10,12 @@ class Vendor < ApplicationRecord
   def states_sold_in
     markets.pluck(:state).uniq
   end
+
+  def self.multiple_states
+    Vendor.joins(:markets)
+      .select("vendors.*, COUNT(DISTINCT markets.state) as state_count")
+      .group("vendors.id")
+      .having("COUNT(DISTINCT markets.state) > 1")
+      .order(state_count: :desc)
+  end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -18,4 +18,12 @@ class Vendor < ApplicationRecord
       .having("COUNT(DISTINCT markets.state) > 1")
       .order(state_count: :desc)
   end
+
+  def self.popular_states(limit = nil)
+    Vendor.joins(:markets)
+      .select("markets.state as state, COUNT(vendors.id) as number_of_vendors")
+      .group("markets.state")
+      .order(number_of_vendors: :desc)
+      .limit(limit)
+  end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -6,4 +6,8 @@ class Vendor < ApplicationRecord
                         :contact_name,
                         :contact_phone
   validates :credit_accepted, inclusion: {in: [true, false], message: "cannot be left blank"}
+
+  def states_sold_in
+    markets.pluck(:state).uniq
+  end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -12,7 +12,7 @@ class Vendor < ApplicationRecord
   end
 
   def self.multiple_states
-    Vendor.joins(:markets)
+    joins(:markets)
       .select("vendors.*, COUNT(DISTINCT markets.state) as state_count")
       .group("vendors.id")
       .having("COUNT(DISTINCT markets.state) > 1")
@@ -20,10 +20,22 @@ class Vendor < ApplicationRecord
   end
 
   def self.popular_states(limit = nil)
-    Vendor.joins(:markets)
+    joins(:markets)
       .select("markets.state as state, COUNT(vendors.id) as number_of_vendors")
       .group("markets.state")
       .order(number_of_vendors: :desc)
       .limit(limit)
+  end
+
+  def self.search(state)
+    select("vendors.id, vendors.name, vendors.description, vendors.contact_name, vendors.contact_phone, vendors.credit_accepted, market_count")
+      .from(
+          Vendor.joins(:markets)
+            .select("vendors.*, COUNT(markets.id) as market_count")
+            .group("vendors.id"), :vendors)
+      .joins(:markets)
+      .where("markets.state ILIKE ?", "%#{state}%")
+      .order(market_count: :desc)
+      .distinct
   end
 end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -10,40 +10,4 @@ class MarketSerializer
               :lon,
               :vendor_count
 
-
-  # def self.format_markets(markets)
-  #   markets.map do |market|
-  #     { 
-  #       id: market.id,
-  #       type: "market",
-  #       attributes: {
-  #         name: market.name,
-  #         street: market.street,
-  #         city: market.city,
-  #         county: market.county,
-  #         state: market.state,
-  #         zip: market.zip,
-  #         lat: market.lat,
-  #         lon: market.lon,
-  #         vendor_count: market.vendor_count
-  #     }}
-  #   end
-  # end
-
-  # def self.format_market(market)
-  #   { 
-  #     id: market.id,
-  #     type: "market",
-  #     attributes: {
-  #       name: market.name,
-  #       street: market.street,
-  #       city: market.city,
-  #       county: market.county,
-  #       state: market.state,
-  #       zip: market.zip,
-  #       lat: market.lat,
-  #       lon: market.lon,
-  #       vendor_count: market.vendor_count
-  #   }}
-  # end
 end

--- a/app/serializers/state_serializer.rb
+++ b/app/serializers/state_serializer.rb
@@ -1,0 +1,9 @@
+class StateSerializer 
+  def self.serialize(states)
+    data = []
+    states.each do |state|
+      data << {state: state.state, number_of_vendors: state.number_of_vendors}
+    end
+    { data: data }
+  end
+end

--- a/app/serializers/vendor_serializer.rb
+++ b/app/serializers/vendor_serializer.rb
@@ -4,5 +4,6 @@ class VendorSerializer
               :description, 
               :contact_name, 
               :contact_phone, 
-              :credit_accepted
+              :credit_accepted,
+              :states_sold_in
 end

--- a/app/services/tomtom_service.rb
+++ b/app/services/tomtom_service.rb
@@ -8,16 +8,4 @@ class TomtomService
       f.params[:key] = Rails.application.credentials.tomtom[:key]
     end
   end
-
-  # def format_atms
-  #   response = JSON.parse(atm_search.body, symbolize_names: true)
-  #   response[:results].map do |atm|
-  #     { distance: atm[:distance], #calculated in meters... change to miles? Or other?
-  #       name: atm[:poi][:name],
-  #       address: atm[:address], #still a nested hash
-  #       lat: atm[:position][:lat],
-  #       lon: atm[:position][:lon]
-  #     }
-  #   end
-  # end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         resources :vendors, only: [:index], controller: :market_vendors
       end
       get "/vendors/multiple_states", to: "vendors#multiple_states"
+      get "/vendors/popular_states", to: "vendors#popular_states"
       resources :vendors, only: [:show, :create, :update, :destroy]
       resource :market_vendors, only: [:create, :destroy]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :markets, only: [:index, :show] do
         resources :vendors, only: [:index], controller: :market_vendors
       end
+      get "/vendors/multiple_states", to: "vendors#multiple_states"
       resources :vendors, only: [:show, :create, :update, :destroy]
       resource :market_vendors, only: [:create, :destroy]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       end
       get "/vendors/multiple_states", to: "vendors#multiple_states"
       get "/vendors/popular_states", to: "vendors#popular_states"
-      resources :vendors, only: [:show, :create, :update, :destroy]
+      resources :vendors, only: [:index, :show, :create, :update, :destroy]
       resource :market_vendors, only: [:create, :destroy]
     end
   end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe Vendor do
     it { should allow_value(false).for(:credit_accepted) }
     it { should_not allow_value(nil).for(:credit_accepted) }
   end
+
+  it "can return number of states that vendor sells in" do
+    vendor = create(:vendor)
+    m1 = create(:market, state: "Colorado")
+    m2 = create(:market, state: "California")
+    m3 = create(:market, state: "Oregon")
+
+    create(:market_vendor, market: m1, vendor: vendor)
+    create(:market_vendor, market: m2, vendor: vendor)
+    create(:market_vendor, market: m3, vendor: vendor)
+
+    expect(vendor.states_sold_in).to eq(["Colorado", "California", "Oregon"])
+  end
 end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -28,4 +28,47 @@ RSpec.describe Vendor do
 
     expect(vendor.states_sold_in).to eq(["Colorado", "California", "Oregon"])
   end
+
+  it "can return all vendors who sell in more than one state, ordered by states_sold_in" do
+    market1 = create(:market, state: "Alabama")
+    market2 = create(:market, state: "Alaska")
+    market3 = create(:market, state: "Arizona")
+    market4 = create(:market, state: "Arkansas")
+    market5 = create(:market, state: "California")
+    market6 = create(:market, state: "Colorado")
+    vendor1 = create(:vendor)
+    vendor2 = create(:vendor)
+    vendor3 = create(:vendor)
+    vendor4 = create(:vendor)
+    vendor5 = create(:vendor)
+    vendor6 = create(:vendor)
+
+    MarketVendor.create(market: market1, vendor: vendor1)
+    MarketVendor.create(market: market2, vendor: vendor1)
+    MarketVendor.create(market: market3, vendor: vendor1)
+    MarketVendor.create(market: market4, vendor: vendor1)
+    MarketVendor.create(market: market5, vendor: vendor1)
+    MarketVendor.create(market: market6, vendor: vendor1)
+    
+    MarketVendor.create(market: market1, vendor: vendor5)
+    MarketVendor.create(market: market2, vendor: vendor5)
+    MarketVendor.create(market: market3, vendor: vendor5)
+    MarketVendor.create(market: market4, vendor: vendor5)
+    MarketVendor.create(market: market5, vendor: vendor5)
+
+    MarketVendor.create(market: market1, vendor: vendor3)
+    MarketVendor.create(market: market2, vendor: vendor3)
+    MarketVendor.create(market: market3, vendor: vendor3)
+
+    MarketVendor.create(market: market1, vendor: vendor4)
+    MarketVendor.create(market: market2, vendor: vendor4)
+    MarketVendor.create(market: market3, vendor: vendor4)
+    MarketVendor.create(market: market4, vendor: vendor4)
+
+    MarketVendor.create(market: market1, vendor: vendor2)
+
+    MarketVendor.create(market: market1, vendor: vendor6)
+
+    expect(Vendor.multiple_states).to eq([vendor1, vendor5, vendor4, vendor3])
+  end
 end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -71,4 +71,53 @@ RSpec.describe Vendor do
 
     expect(Vendor.multiple_states).to eq([vendor1, vendor5, vendor4, vendor3])
   end
+
+  it "can report all states and how many vendors sell there" do
+    ca_market = create(:market, state: "California")
+    co_market = create(:market, state: "Colorado")
+    pa_market = create(:market, state: "Pennsylvania")
+    ny_market = create(:market, state: "New York")
+    al_market = create(:market, state: "Alabama")
+
+    create_list(:market_vendor, 10, market: ca_market)
+    create_list(:market_vendor, 29, market: co_market)
+    create_list(:market_vendor, 15, market: pa_market)
+    create_list(:market_vendor, 31, market: ny_market)
+    create_list(:market_vendor, 5, market: al_market)
+
+    states = Vendor.popular_states
+    expect(states[0].state).to eq("New York")
+    expect(states[0].number_of_vendors).to eq(31)
+
+    expect(states[1].state).to eq("Colorado")
+    expect(states[1].number_of_vendors).to eq(29)
+
+    expect(states[2].state).to eq("Pennsylvania")
+    expect(states[2].number_of_vendors).to eq(15)
+
+    expect(states[3].state).to eq("California")
+    expect(states[3].number_of_vendors).to eq(10)
+
+    expect(states[4].state).to eq("Alabama")
+    expect(states[4].number_of_vendors).to eq(5)
+  end
+
+  it "can take in an optional limit for top popular states" do
+    ca_market = create(:market, state: "California")
+    co_market = create(:market, state: "Colorado")
+    pa_market = create(:market, state: "Pennsylvania")
+    ny_market = create(:market, state: "New York")
+    al_market = create(:market, state: "Alabama")
+
+    create_list(:market_vendor, 10, market: ca_market)
+    create_list(:market_vendor, 29, market: co_market)
+    create_list(:market_vendor, 15, market: pa_market)
+    create_list(:market_vendor, 31, market: ny_market)
+    create_list(:market_vendor, 5, market: al_market)
+
+    states = Vendor.popular_states(3)
+
+    names = states.map { |state| state.state }
+    expect(names).to eq(["New York", "Colorado", "Pennsylvania"])
+  end
 end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -120,4 +120,57 @@ RSpec.describe Vendor do
     names = states.map { |state| state.state }
     expect(names).to eq(["New York", "Colorado", "Pennsylvania"])
   end
+
+  it "can find vendors by state, ordered by popularity (how many markets they sell at)" do
+    market1 = create(:market, state: "Alabama")
+    other_al_market = create(:market, state: "Alabama")
+    market2 = create(:market, state: "Alaska")
+    market3 = create(:market, state: "Arizona")
+    market4 = create(:market, state: "Arkansas")
+    market5 = create(:market, state: "California")
+    market6 = create(:market, state: "Colorado")
+    vendor1 = create(:vendor)
+    vendor2 = create(:vendor)
+    vendor3 = create(:vendor)
+    vendor4 = create(:vendor)
+    vendor5 = create(:vendor)
+    vendor6 = create(:vendor)
+
+    MarketVendor.create(market: market1, vendor: vendor1)
+    MarketVendor.create(market: other_al_market, vendor: vendor1)
+    MarketVendor.create(market: market2, vendor: vendor1)
+    MarketVendor.create(market: market3, vendor: vendor1)
+    MarketVendor.create(market: market4, vendor: vendor1)
+    MarketVendor.create(market: market5, vendor: vendor1)
+    MarketVendor.create(market: market6, vendor: vendor1)
+    
+    MarketVendor.create(market: market1, vendor: vendor5)
+    MarketVendor.create(market: market2, vendor: vendor5)
+    MarketVendor.create(market: market3, vendor: vendor5)
+    MarketVendor.create(market: market4, vendor: vendor5)
+    MarketVendor.create(market: market5, vendor: vendor5)
+
+    MarketVendor.create(market: market1, vendor: vendor3)
+    MarketVendor.create(market: market2, vendor: vendor3)
+    MarketVendor.create(market: market3, vendor: vendor3)
+
+    MarketVendor.create(market: market1, vendor: vendor4)
+    MarketVendor.create(market: market2, vendor: vendor4)
+    MarketVendor.create(market: market3, vendor: vendor4)
+    MarketVendor.create(market: market4, vendor: vendor4)
+
+    MarketVendor.create(market: market1, vendor: vendor2)
+
+    MarketVendor.create(market: market2, vendor: vendor6)
+
+    al_vendors = Vendor.search("Alabama")
+    
+    expect(al_vendors).to eq([vendor1, vendor5, vendor4, vendor3, vendor2])
+
+    ak_vendors = Vendor.search("Alaska")
+    expect(ak_vendors).to eq([vendor1, vendor5, vendor4, vendor3, vendor6])
+
+    ar_vendors = Vendor.search("Arkansas")
+    expect(ar_vendors).to eq([vendor1, vendor5, vendor4])
+  end
 end

--- a/spec/requests/api/v0/vendor_request_spec.rb
+++ b/spec/requests/api/v0/vendor_request_spec.rb
@@ -1,7 +1,110 @@
 require "rails_helper"
 
 RSpec.describe "Vendor API requests" do
-  context "get endpoint" do
+  context "vendor index endpoint" do
+    it "returns all vendors in system" do
+      create_list(:market_vendor, 10)
+      get "/api/v0/vendors"
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed_response).to have_key(:data)
+      vendors = parsed_response[:data]
+
+      expect(vendors.count).to eq(10)
+      vendors.each do |vendor|
+        expect(vendor).to have_key(:id)
+        expect(vendor[:id]).to be_a(String)
+
+        expect(vendor).to have_key(:type)
+        expect(vendor[:type]).to eq("vendor")
+
+        expect(vendor).to have_key(:attributes)
+        expect(vendor[:attributes]).to be_a(Hash)
+
+        expect(vendor[:attributes]).to have_key(:name)
+        expect(vendor[:attributes][:name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:description)
+        expect(vendor[:attributes][:description]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_name)
+        expect(vendor[:attributes][:contact_name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_phone)
+        expect(vendor[:attributes][:contact_phone]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:credit_accepted)
+        expect(vendor[:attributes][:credit_accepted]).to eq(true).or eq(false)
+
+        expect(vendor[:attributes]).to have_key(:states_sold_in)
+        expect(vendor[:attributes][:states_sold_in]).to be_an(Array)
+      end
+    end
+
+    it "returns all vendors for a given state in order of popularity" do
+      market1 = create(:market, state: "Alabama")
+      market2 = create(:market, state: "Alaska")
+      market3 = create(:market, state: "Arizona")
+      market4 = create(:market, state: "Arkansas")
+      market5 = create(:market, state: "California")
+      market6 = create(:market, state: "Colorado")
+      vendor1 = create(:vendor)
+      vendor2 = create(:vendor)
+      vendor3 = create(:vendor)
+      vendor4 = create(:vendor)
+      vendor5 = create(:vendor)
+      vendor6 = create(:vendor)
+
+      MarketVendor.create(market: market1, vendor: vendor1)
+      MarketVendor.create(market: market2, vendor: vendor1)
+      MarketVendor.create(market: market3, vendor: vendor1)
+      MarketVendor.create(market: market4, vendor: vendor1)
+      MarketVendor.create(market: market5, vendor: vendor1)
+      MarketVendor.create(market: market6, vendor: vendor1)
+      
+      MarketVendor.create(market: market1, vendor: vendor5)
+      MarketVendor.create(market: market2, vendor: vendor5)
+      MarketVendor.create(market: market3, vendor: vendor5)
+      MarketVendor.create(market: market4, vendor: vendor5)
+      MarketVendor.create(market: market5, vendor: vendor5)
+  
+      MarketVendor.create(market: market1, vendor: vendor3)
+      MarketVendor.create(market: market2, vendor: vendor3)
+      MarketVendor.create(market: market3, vendor: vendor3)
+  
+      MarketVendor.create(market: market1, vendor: vendor4)
+      MarketVendor.create(market: market2, vendor: vendor4)
+      MarketVendor.create(market: market3, vendor: vendor4)
+      MarketVendor.create(market: market4, vendor: vendor4)
+  
+      MarketVendor.create(market: market1, vendor: vendor2)
+  
+      MarketVendor.create(market: market2, vendor: vendor6)
+
+      get "/api/v0/vendors", params: {
+        state: "Alabama"
+      }
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+      vendors = parsed_response[:data]
+
+      expect(vendors.count).to eq(5)
+
+      vendor_objects = vendors.map { |vendor| Vendor.find(vendor[:id].to_i) }
+
+      vendor_objects.each_cons(2) do |first, second|
+        expect(first.markets.count >= second.markets.count).to eq(true)
+      end
+    end
+  end
+
+  context "show endpoint" do
     it "can return one vendor object + attributes" do
       new_vendor = create(:vendor)
       get "/api/v0/vendors/#{new_vendor.id}"
@@ -304,7 +407,7 @@ RSpec.describe "Vendor API requests" do
     end
   end
 
-  context "states_sold_in search" do
+  context "multiple_states search endpoint" do
     it "returns all vendors that sell in more than one state" do
       market1 = create(:market, state: "Alabama")
       market2 = create(:market, state: "Alaska")
@@ -364,7 +467,7 @@ RSpec.describe "Vendor API requests" do
     end
   end
 
-context "popular states search" do
+context "popular states search endpoint" do
     it "can return list of states and count of vendors selling there" do
       ca_market = create(:market, state: "California")
       co_market = create(:market, state: "Colorado")

--- a/spec/requests/api/v0/vendor_request_spec.rb
+++ b/spec/requests/api/v0/vendor_request_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe "Vendor API requests" do
 
       expect(vendor[:attributes]).to have_key(:credit_accepted)
       expect(vendor[:attributes][:credit_accepted]).to eq(true).or eq(false)
+
+      expect(vendor[:attributes]).to have_key(:states_sold_in)
+      expect(vendor[:attributes][:states_sold_in]).to be_an(Array)
     end
 
     it "returns an error if vendor id is invalid" do
@@ -94,7 +97,10 @@ RSpec.describe "Vendor API requests" do
       expect(vendor[:attributes][:contact_phone]).to eq("8389928383")
   
       expect(vendor[:attributes]).to have_key(:credit_accepted)
-      expect(vendor[:attributes][:credit_accepted]).to eq(false)    
+      expect(vendor[:attributes][:credit_accepted]).to eq(false) 
+
+      expect(vendor[:attributes]).to have_key(:states_sold_in)
+      expect(vendor[:attributes][:states_sold_in]).to be_an(Array)
     end
 
     it "raises an error for a missing name or description" do

--- a/spec/serializers/state_serializer_spec.rb
+++ b/spec/serializers/state_serializer_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe StateSerializer do
+  it "can format state info in a hash" do
+    ca_market = create(:market, state: "California")
+    create_list(:market_vendor, 40, market: ca_market)
+
+    expected = { data: 
+          [
+            {
+              state: "California",
+              number_of_vendors: 40
+            }
+          ]
+        }
+    
+    expect(StateSerializer.serialize(Vendor.popular_states)).to eq(expected)
+  end
+
+  it "works for multiple states" do
+    ca_market = create(:market, state: "California")
+    create_list(:market_vendor, 40, market: ca_market)
+    co_market = create(:market, state: "Colorado")
+    create_list(:market_vendor, 20, market: co_market)
+
+    expected = { data: 
+          [
+            {
+              state: "California",
+              number_of_vendors: 40
+            },
+            {
+              state: "Colorado",
+              number_of_vendors: 20
+            }
+          ]
+        }
+    
+    expect(StateSerializer.serialize(Vendor.popular_states)).to eq(expected)
+  end
+end


### PR DESCRIPTION
Vendors `show` endpoint updated to include an attribute for states_sold_in, displaying an array of all states that that vendor is present in

Three new endpoints created:
`/api/v0/vendors/multiple_states` 
```
Returns a list of vendors that sell at markets in more than one state
Vendors are returned in order by the number of states they sell in
```
`/api/v0/vendors/popular_states`
```
Returns a list of states that have markets in the database, with a count of how many vendors sell at markets in that state
States are in order by how many vendors sell in that state, in descending order
```
`/api/v0/vendors`
```
RESTful index endpoint, returning list of all vendors
Additional functionality: Allows for user to pass in a search query for a state, and return only the vendors that sell in that state
Vendors are listed in order by how many markets they sell at, descending
```